### PR TITLE
Add a CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,14 @@
+# The interesting parts
+contracts/ @c0deMunk33
+test/ @c0deMunk33
+migrations/ @c0deMunk33
+
+# Mainly node scripts and organisation
+package.json @c0deMunk33 @edd
+package-lock.json @edd
+docs/ @edd
+
+README.md @c0deMunk33 @edd @ashleyvega
+
+# Making nice badges
+.github/ @ashleyvega @edd


### PR DESCRIPTION
As a way to document who generally should be pulled in to PRs / who people can direct issues or questions to, I've added a CODEOWNERS file that will result in Github showing the relevant person/people at the top of the file. It's generally structured as:

@C0deMunk33: All the actual contracts, tests and migrations
@ashleyvega & @edd: packaging, test running, automations that sit around the interesting parts

Given that the rate of change on this repo is going to be low, consider this more documentation than anything else.